### PR TITLE
Installing admin wasn't setting is_admin attribute

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -75,10 +75,16 @@ var loadProviders = function(req, res, next) {
 
 var notInstalled = function(req, res, next) {
   Dashboard.findOne({ 'admin': { $exists: true } }, function(err, dash){
-    if(!dash) {
-      dash = new Dashboard({ admin: req.user.id });
+    if(!dash || (dash.admin == req.user.id && !req.user.is_admin)) {
+      if (!dash) {
+        dash = new Dashboard({ admin: req.user.id });
+        dash.save(function(){
+          if(err) return res.send(500);
+        });
+      }
       res.locals.user = req.user;
-      dash.save(function(){
+      req.user.is_admin = true;
+      req.user.save(function(){
         if(err) return res.send(500);
         next();
       });


### PR DESCRIPTION
Installing admin wasn't setting is_admin attribute. The implementation is checking if the dashboard exists but the admin is not set and let you fix that by calling again the url yoursite.com/install
