### PR TITLE
Remove query and hash from Discourse URLs.

### DIFF
--- a/public/js/discourse.js
+++ b/public/js/discourse.js
@@ -1,7 +1,7 @@
 var discourseUrl = window.hackdash && window.hackdash.discourseUrl;
 if (discourseUrl) {
   DiscourseEmbed = {
-    discourseEmbedUrl: window.location.href,
+    discourseEmbedUrl: [location.protocol, '//', location.host, location.pathname].join(''),
     discourseUrl: discourseUrl
   };
   // The only way to re-execute Discourse embedding script seems to be to re-insert it.


### PR DESCRIPTION
In some cases, hackdash adds a query to the URL of the projects. This patch ignore the query, to ensure that 2 different Discourse forums are not created for the same project.