### PR TITLE
Switch to passport-github2 to handle github API updates

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -76,8 +76,9 @@ const generateStrategy = provider => {
   app.get(`/auth/${provider}/callback`, passport.authenticate(provider, { failureRedirect: '/' }), redirectSubdomain);
 
   // Require provider own module
+  const providerMod = provider == 'github' ? 'github2' : provider;
   // TODO: Figure out how to use ES2015 syntax instead of requires
-  const Strategy = require(`passport-${provider}`).Strategy;
+  const Strategy = require(`passport-${providerMod}`).Strategy;
 
   passport.use(new Strategy(keys[provider], async (token, tokenSecret, profile, done) => {
     let user = await User.findOne({provider_id: profile.id, provider: provider}).exec();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nodemailer": "0.4.4",
     "passport": "0.2.2",
     "passport-facebook": "2.0.0",
-    "passport-github": "0.1.5",
+    "passport-github2": "^0.1.12",
     "passport-http": "^0.3.0",
     "passport-meetup": "0.1.2",
     "passport-twitter": "1.0.3",


### PR DESCRIPTION
Fixes this error which occurs when trying to authenticate via github

```
nodejs | error { failed to fetch user profile (status: 400 data: {"message":"Must specify access token via Authorization header","documentation_url":"https://docs.github.com/v3/#oauth2-token-sent-in-a-header"})
nodejs | at /home/app/nodemodules/passport-github/lib/passport-github/strategy.js:90:28
nodejs | at passBackControl (/home/app/nodemodules/oauth/lib/oauth2.js:132:9)
nodejs | at IncomingMessage.<anonymous> (/home/app/nodemodules/oauth/lib/oauth2.js:157:7)
nodejs | at IncomingMessage.emit (events.js:203:15)
nodejs | at endReadableNT (streamreadable.js:1145:12)
nodejs | at process.tickCallback (internal/process/nexttick.js:63:19)
nodejs | name: 'InternalOAuthError',
nodejs | message: 'failed to fetch user profile',
nodejs | oauthError:
nodejs | { statusCode: 400,
nodejs | data:
nodejs | '{"message":"Must specify access token via Authorization header","documentationurl":"https://docs.github.com/v3/#oauth2-token-sent-in-a-header"}' } }
```